### PR TITLE
Updating release notes fix

### DIFF
--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -67,7 +67,7 @@ include::https://raw.githubusercontent.com/NetAppDocs/console-licenses-subscript
 
 == Disaster Recovery
 
-include::https://raw.githubusercontent.com/NetAppDocs/storage-management-disaster-recovery/main/release-notes/dr-whats-new.adoc[tag=whats-new,leveloffset=+1]
+include::https://raw.githubusercontent.com/NetAppDocs/data-services-disaster-recovery/main/release-notes/dr-whats-new.adoc[tag=whats-new,leveloffset=+1]
 
 == E-Series systems
 


### PR DESCRIPTION
This pull request updates the documentation source for the Disaster Recovery section in the `whats-new.adoc` file. The change ensures that the release notes now reference the correct repository for disaster recovery updates.

Documentation update:

* Changed the Disaster Recovery release notes source to use `data-services-disaster-recovery` instead of `storage-management-disaster-recovery` in `whats-new.adoc`.