### PR TITLE
Fixing Cloud Tiering heading

### DIFF
--- a/_include/data-services-cloud-tiering.adoc
+++ b/_include/data-services-cloud-tiering.adoc
@@ -1,1 +1,1 @@
-Cloud Tiering
+=== Cloud Tiering


### PR DESCRIPTION
This pull request makes a minor formatting update to the `_include/data-services-cloud-tiering.adoc` file by changing the "Cloud Tiering" heading to use the correct AsciiDoc heading level.